### PR TITLE
Add Chainlit-based SQL agent with admin panel

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+__pycache__/
+*.pyc

--- a/admin_app.py
+++ b/admin_app.py
@@ -1,0 +1,37 @@
+import json
+from pathlib import Path
+
+from fastapi import FastAPI, Form, Request
+from fastapi.responses import HTMLResponse, RedirectResponse
+from fastapi.templating import Jinja2Templates
+
+CONFIG_FILE = Path("config.json")
+
+app = FastAPI()
+templates = Jinja2Templates(directory="templates")
+
+
+def load_config() -> dict:
+    with CONFIG_FILE.open("r", encoding="utf-8") as f:
+        return json.load(f)
+
+
+def save_config(config: dict) -> None:
+    with CONFIG_FILE.open("w", encoding="utf-8") as f:
+        json.dump(config, f, indent=2)
+
+
+@app.get("/", response_class=HTMLResponse)
+async def read_root(request: Request):
+    config = load_config()
+    return templates.TemplateResponse("admin.html", {"request": request, "config": config})
+
+
+@app.post("/update")
+async def update(instructions: str = Form(...), samples: str = Form("[]")):
+    config = {
+        "instructions": instructions,
+        "samples": json.loads(samples),
+    }
+    save_config(config)
+    return RedirectResponse("/", status_code=303)

--- a/app.py
+++ b/app.py
@@ -1,0 +1,73 @@
+import os
+import json
+from typing import List, Tuple
+
+import chainlit as cl
+from openai import AzureOpenAI
+import pyodbc
+
+CONFIG_FILE = "config.json"
+
+
+def load_config() -> dict:
+    """Load the agent configuration from disk."""
+    with open(CONFIG_FILE, "r", encoding="utf-8") as f:
+        return json.load(f)
+
+
+def run_sql(query: str) -> Tuple[List[str], List[Tuple]]:
+    """Execute a SQL query and return columns and rows."""
+    conn = pyodbc.connect(
+        f"DRIVER={{ODBC Driver 18 for SQL Server}};"
+        f"SERVER={os.environ.get('DB_SERVER')};"
+        f"DATABASE={os.environ.get('DB_DATABASE')};"
+        f"UID={os.environ.get('DB_USER')};"
+        f"PWD={os.environ.get('DB_PASSWORD')};"
+        "TrustServerCertificate=yes;"
+    )
+    cursor = conn.cursor()
+    cursor.execute(query)
+    columns = [column[0] for column in cursor.description]
+    rows = cursor.fetchall()
+    conn.close()
+    return columns, rows
+
+
+def find_sql(user_input: str) -> str | None:
+    """Find a matching SQL statement from config based on user input."""
+    config = load_config()
+    for sample in config.get("samples", []):
+        if sample["question"].lower() in user_input.lower():
+            return sample["sql"]
+    return None
+
+
+@cl.on_chat_start
+async def start_chat():
+    config = load_config()
+    await cl.Message(content=config.get("instructions", "")).send()
+
+
+@cl.on_message
+async def main(message: cl.Message):
+    user_text = message.content
+    sql = find_sql(user_text)
+
+    if sql:
+        columns, rows = run_sql(sql)
+        table = cl.DataTable(columns=columns, data=rows)
+        await cl.Message(content="Query result", elements=[table]).send()
+        return
+
+    client = AzureOpenAI(
+        api_key=os.environ.get("AZURE_OPENAI_API_KEY"),
+        api_version="2023-07-01-preview",
+        azure_endpoint=os.environ.get("AZURE_OPENAI_ENDPOINT"),
+    )
+
+    response = client.chat.completions.create(
+        model=os.environ.get("AZURE_OPENAI_DEPLOYMENT"),
+        messages=[{"role": "user", "content": user_text}],
+    )
+
+    await cl.Message(content=response.choices[0].message.content).send()

--- a/config.json
+++ b/config.json
@@ -1,0 +1,9 @@
+{
+  "instructions": "Ask a question about vehicle lifecycle and I will query the database.",
+  "samples": [
+    {
+      "question": "show last 10 vehicles",
+      "sql": "SELECT TOP 10 * FROM [DW].[FCT_VEHICLE_LIFECYCLE_WITH_ORDER_PLAN]"
+    }
+  ]
+}

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,6 @@
+chainlit
+fastapi
+uvicorn
+openai
+pyodbc
+jinja2

--- a/templates/admin.html
+++ b/templates/admin.html
@@ -1,0 +1,16 @@
+<!DOCTYPE html>
+<html>
+<head>
+    <title>Admin Panel</title>
+</head>
+<body>
+<h1>Agent Configuration</h1>
+<form action="/update" method="post">
+    <label>Instructions</label><br>
+    <textarea name="instructions" rows="5" cols="80">{{ config["instructions"] }}</textarea><br><br>
+    <label>Samples (JSON)</label><br>
+    <textarea name="samples" rows="10" cols="80">{{ config["samples"] | tojson }}</textarea><br><br>
+    <input type="submit" value="Save">
+</form>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- add Chainlit app using Azure OpenAI and SQL Server
- include FastAPI admin panel to edit agent instructions and sample queries

## Testing
- `python -m py_compile app.py admin_app.py`


------
https://chatgpt.com/codex/tasks/task_e_6899b00d9bac83228f5515ca7aed169f